### PR TITLE
Fix mobile sections overlapping

### DIFF
--- a/Desarrollo web/WebPersonal/style.css
+++ b/Desarrollo web/WebPersonal/style.css
@@ -360,9 +360,19 @@ header p {
 }
 
 @media (max-width: 480px) {
+    .stack-item {
+        width: 3rem;
+        height: 3rem;
+    }
+
     .stack-item img {
-        width: 4rem; /* Más pequeño para pantallas pequeñas */
-        height: 4rem;
+        width: 100%;
+        height: 100%;
+    }
+
+    .stack-grid {
+        row-gap: 3rem;
+        column-gap: 1rem;
     }
 
     .h2-stack {


### PR DESCRIPTION
Arregla el problema de solapamiento entre secciones para la gran mayoría de celulares.
NO es un arreglo perfecto, habría que rearmar gran parte del CSS.
El problema es que el contenido del section crece mas que el alto de la pantalla y el overflow queda sobre los otros.
Para arreglarlo, ajusté un toque los tamaños de los iconos.
