### PR TITLE
feat: mejorar la accesibilidad de los enlaces de redes sociales

### DIFF
--- a/Desarrollo web/WebPersonal/index.html
+++ b/Desarrollo web/WebPersonal/index.html
@@ -44,10 +44,10 @@
                         alt="Valentina Werle"
                     />
                     <div class="social-links">
-                        <a href="https://www.linkedin.com/in/valentinawerle/" class="social-icon">
+                        <a href="https://www.linkedin.com/in/valentinawerle/" class="social-icon" aria-label="Ir al perfil de LinkedIn de Valentina Werle">
                             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/><rect width="4" height="12" x="2" y="9"/><circle cx="4" cy="4" r="2"/></svg>
                         </a>
-                        <a href="https://github.com/valentinawerle" class="social-icon">
+                        <a href="https://github.com/valentinawerle" class="social-icon" aria-label="Ir al perfil de Github de Valentina Werle">
                             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4"/><path d="M9 18c-4.51 2-5-2-7-2"/></svg>
                         </a>
                     </div>


### PR DESCRIPTION
Agregados atributos `aria-label` a los enlaces de redes sociales para mejorar la accesibilidad con lectores de pantalla. Ahora cada enlace describe claramente su destino, brindando una mejor experiencia para usuarios que dependen de tecnologías de asistencia.

### Antes
![Captura de pantalla 2024-11-05 102044](https://github.com/user-attachments/assets/0a65bb02-ac19-47d2-97a1-59246c4d086a)

### Después
![Captura de pantalla 2024-11-05 101715](https://github.com/user-attachments/assets/08d921a4-f6cc-4ce9-a506-fbacada32e74)
